### PR TITLE
chore(ci): update actions/cache to v4 in workflows

### DIFF
--- a/.github/workflows/publish-main.yml
+++ b/.github/workflows/publish-main.yml
@@ -23,7 +23,7 @@ jobs:
           echo ::set-output name=tags::${IMAGE_NAME}:latest
 
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}

--- a/.github/workflows/publish-main.yml
+++ b/.github/workflows/publish-main.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Prepare
         id: prep
         run: |
-          echo ::set-output name=tags::${IMAGE_NAME}:latest
+          echo "tags=${IMAGE_NAME}:latest" >> "$GITHUB_OUTPUT"
 
       - name: Cache Docker layers
         uses: actions/cache@v4

--- a/.github/workflows/publish-on-branch.yml
+++ b/.github/workflows/publish-on-branch.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Prepare
         id: prep
         run: |
-          echo ::set-output name=tags::${IMAGE_NAME}:${GITHUB_REF##*/}
+          echo "tags=${IMAGE_NAME}:${GITHUB_REF##*/}" >> "$GITHUB_OUTPUT"
 
       - name: Cache Docker layers
         uses: actions/cache@v4

--- a/.github/workflows/publish-on-branch.yml
+++ b/.github/workflows/publish-on-branch.yml
@@ -24,7 +24,7 @@ jobs:
           echo ::set-output name=tags::${IMAGE_NAME}:${GITHUB_REF##*/}
 
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}

--- a/.github/workflows/publish-on-tag.yml
+++ b/.github/workflows/publish-on-tag.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Prepare
         id: prep
         run: |
-          echo ::set-output name=tags::${IMAGE_NAME}:${GITHUB_REF/refs\/tags\//}
+          echo "tags=${IMAGE_NAME}:${GITHUB_REF/refs\/tags\//}" >> "$GITHUB_OUTPUT"
 
       - name: Cache Docker layers
         uses: actions/cache@v4

--- a/.github/workflows/publish-on-tag.yml
+++ b/.github/workflows/publish-on-tag.yml
@@ -25,7 +25,7 @@ jobs:
           echo ::set-output name=tags::${IMAGE_NAME}:${GITHUB_REF/refs\/tags\//}
 
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}


### PR DESCRIPTION
Update the Docker publish GitHub Actions workflows to use actions/cache@v4 instead of v2. This brings improved performance, security, and compatibility with the latest GitHub Actions features.